### PR TITLE
hidpi simplification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,7 @@ Parameters
    should be
 -  ``height`` (mandatory integer): The number of pixels high the image
    should be
--  ``col`` (optional): The number of Vanilla columns the image should
-   span (helps define break points efficiently)
+-  ``hi_def`` (mandatory boolean): Has an image been uploaded 2x the width and height of the desired size
 -  ``extra_classes`` (optional): Class string to add to img element
 -  `extra attributes` (optional): Extra ``<img>`` attributes (e.g. 
    ``id``) can be passed as additional arguments
@@ -42,7 +41,8 @@ Markup.
         url="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png",
         alt="Operational dashboard",
         width="1040",
-        height="585"
+        height="585",
+        hi_def=True
     )
 
 However, the most common usage is to add it to Django or Flask template
@@ -94,7 +94,7 @@ Use it in templates:
 
     # templates/mytemplate.html
 
-    {% image url="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png" alt="Operational dashboard" width="1040" height="585" %}
+    {% image url="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png" alt="Operational dashboard" width="1040" height="585" hi_def=True %}
 
 Flask usage
 ~~~~~~~~~~~
@@ -125,7 +125,8 @@ Use it in templates:
         url="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png",
         alt="Operational dashboard",
         width="1040",
-        height="585"
+        height="585",
+        hi_def: True,
       ) | safe
     }}
 
@@ -137,11 +138,8 @@ All the above examples will generate the following markup:
 .. code:: html
 
     <img 
-      data-srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_412/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585 460w
-                  ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_572/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585 620w
-                  ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_720/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585 767w
-                  ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_990/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585 1030w"
-      data-src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585" 
+      data-srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_2080,h_1170/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png x2"
+      data-src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_1040,h_585/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png" 
       alt="Operational dashboard"
       width="1040"
       height="585"
@@ -150,13 +148,37 @@ All the above examples will generate the following markup:
 
     <noscript>
       <img
-        srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_412/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585 460w
-                ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_572/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585 620w
-                ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_720/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585 767w
-                ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_990/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585 1030w"
-        src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585" 
+        srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_2080,h_1170/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png x2"
+        src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_1040,h_585/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png" 
         alt="Operational dashboard"
         width="1040"
         height="585"
       />
     </noscript>
+
+
+File sizes
+~~~~~~~~~~
+
+Source:
+https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png
+2560 x 1440 - 300.62kb
+
+Asset server x2 resize:
+https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=2080&h=1170
+2080 x 1170 - 595.67kb
+
+Asset server resize:
+https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585
+1040 x 585 - 221.21kb
+
+Cloudinary x2 resize:
+https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_2080,h_1170/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png
+2080 x 1170 - 163.12kb
+
+Cloudinary resize:
+https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_1040,h_585/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png
+1040 x 585 - 62.80kb
+
+
+

--- a/README.rst
+++ b/README.rst
@@ -138,8 +138,8 @@ All the above examples will generate the following markup:
 .. code:: html
 
     <img 
-      data-srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize/https%3A//assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png%3Fw%3D2080%26h%3D1170 x2"
-      data-src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize/https%3A//assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png%3Fw%3D1040%26h%3D585" 
+      data-srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_2080,h_1170/https%3A//assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png x2"
+      data-src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_1040,h_585/https%3A//assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png" 
       alt="Operational dashboard"
       width="1040"
       height="585"
@@ -148,8 +148,8 @@ All the above examples will generate the following markup:
 
     <noscript>
       <img
-        srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize/https%3A//assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png%3Fw%3D2080%26h%3D1170 x2"
-        src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize/https%3A//assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png%3Fw%3D1040%26h%3D585" 
+        srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_2080,h_1170/https%3A//assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png x2"
+        src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_1040,h_585/https%3A//assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png" 
         alt="Operational dashboard"
         width="1040"
         height="585"
@@ -172,13 +172,18 @@ Asset server resize:
 https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585
 1040 x 585 - 221.21kb
 
-Cloudinary x2 resize:
+Asset server resize x2 + Cloudinary x2 resize:
 https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize/https%3A//assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png%3Fw%3D2080%26h%3D1170
 2080 x 1170 - 194.97kb
 
-Cloudinary resize:
+Asset server resize x1 + Cloudinary x1 resize:
 https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize/https%3A//assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png%3Fw%3D1040%26h%3D585
 1040 x 585 - 109.38kb
 
+Cloudinary x2 resize:
+https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_2080,h_1170/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png
+2080 x 1170 - 163.38
 
-
+Cloudinary x1 resize:
+https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_1040,h_585/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png
+1040 x 585 - 62.80kb

--- a/README.rst
+++ b/README.rst
@@ -138,8 +138,8 @@ All the above examples will generate the following markup:
 .. code:: html
 
     <img 
-      data-srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_2080,h_1170/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png x2"
-      data-src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_1040,h_585/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png" 
+      data-srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize/https%3A//assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png%3Fw%3D2080%26h%3D1170 x2"
+      data-src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize/https%3A//assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png%3Fw%3D1040%26h%3D585" 
       alt="Operational dashboard"
       width="1040"
       height="585"
@@ -148,8 +148,8 @@ All the above examples will generate the following markup:
 
     <noscript>
       <img
-        srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_2080,h_1170/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png x2"
-        src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_1040,h_585/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png" 
+        srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize/https%3A//assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png%3Fw%3D2080%26h%3D1170 x2"
+        src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize/https%3A//assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png%3Fw%3D1040%26h%3D585" 
         alt="Operational dashboard"
         width="1040"
         height="585"
@@ -173,12 +173,12 @@ https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585
 1040 x 585 - 221.21kb
 
 Cloudinary x2 resize:
-https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_2080,h_1170/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png
-2080 x 1170 - 163.12kb
+https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize/https%3A//assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png%3Fw%3D2080%26h%3D1170
+2080 x 1170 - 194.97kb
 
 Cloudinary resize:
-https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize,w_1040,h_585/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png
-1040 x 585 - 62.80kb
+https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,fl_sanitize/https%3A//assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png%3Fw%3D1040%26h%3D585
+1040 x 585 - 109.38kb
 
 
 

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -1,7 +1,7 @@
 # Standard library
 import os
 import sys
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse, parse_qs, urlencode, quote
 
 # Packages
 from jinja2 import Environment, FileSystemLoader
@@ -31,13 +31,28 @@ def image_template(url, alt, width, height, hi_def, **attributes):
         raise Exception("url must contain a hostname")
 
     std_def_cloudinary_options = cloudinary_options.copy()
-    std_def_cloudinary_options.append("w_" + str(width))
-    std_def_cloudinary_options.append("h_" + str(height))
-
     hi_def_cloudinary_options = cloudinary_options.copy()
-    if hi_def:
-        hi_def_cloudinary_options.append("w_" + str(int(width) * 2))
-        hi_def_cloudinary_options.append("h_" + str(int(height) * 2))
+
+    if not url_parts.netloc == "assets.ubuntu.com":
+        std_def_cloudinary_options.append("w_" + str(width))
+        std_def_cloudinary_options.append("h_" + str(height))
+
+        if hi_def:
+            hi_def_cloudinary_options.append("w_" + str(int(width) * 2))
+            hi_def_cloudinary_options.append("h_" + str(int(height) * 2))
+    elif url_parts.path[-4:] != ".svg":
+        query = parse_qs(url_parts.query)
+
+        if hi_def:
+            query["w"] = int(width) * 2
+            query["h"] = int(height) * 2
+        else:
+            query["w"] = int(width)
+            query["h"] = int(height)
+
+        url_list = list(url_parts)
+        url_list[4] = urlencode(query, doseq=True)
+        url = quote(urlunparse(url_list))
 
     # Split out classes from attributes
     # as we need to handle them specially

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -1,7 +1,7 @@
 # Standard library
 import os
 import sys
-from urllib.parse import urlparse, urlunparse, parse_qs, urlencode, quote
+from urllib.parse import urlparse
 
 # Packages
 from jinja2 import Environment, FileSystemLoader
@@ -33,26 +33,12 @@ def image_template(url, alt, width, height, hi_def, **attributes):
     std_def_cloudinary_options = cloudinary_options.copy()
     hi_def_cloudinary_options = cloudinary_options.copy()
 
-    if not url_parts.netloc == "assets.ubuntu.com":
-        std_def_cloudinary_options.append("w_" + str(width))
-        std_def_cloudinary_options.append("h_" + str(height))
+    std_def_cloudinary_options.append("w_" + str(width))
+    std_def_cloudinary_options.append("h_" + str(height))
 
-        if hi_def:
-            hi_def_cloudinary_options.append("w_" + str(int(width) * 2))
-            hi_def_cloudinary_options.append("h_" + str(int(height) * 2))
-    elif url_parts.path[-4:] != ".svg":
-        query = parse_qs(url_parts.query)
-
-        if hi_def:
-            query["w"] = int(width) * 2
-            query["h"] = int(height) * 2
-        else:
-            query["w"] = int(width)
-            query["h"] = int(height)
-
-        url_list = list(url_parts)
-        url_list[4] = urlencode(query, doseq=True)
-        url = quote(urlunparse(url_list))
+    if hi_def:
+        hi_def_cloudinary_options.append("w_" + str(int(width) * 2))
+        hi_def_cloudinary_options.append("h_" + str(int(height) * 2))
 
     # Split out classes from attributes
     # as we need to handle them specially

--- a/canonicalwebteam/templates/image_template.html
+++ b/canonicalwebteam/templates/image_template.html
@@ -1,65 +1,31 @@
 <img
-  {%- if width > 412 %}
-    data-srcset="https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }},w_412/{{ url }} 460w
-               ,https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }},w_824/{{ url }} 920w
-    {%- if width > 572 %}
-               ,https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }},w_572/{{ url }} 620w
-               ,https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }},w_1144/{{ url }} 1240w
-      {%- if width > 720 %}
-               ,https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }},w_720/{{ url }} 767w
-               ,https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }},w_1440/{{ url }} 1534w
-        {%- if width > 990 %}
-               ,https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }},w_990/{{ url }} 1030w
-               ,https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }},w_1980/{{ url }} 2060w
-        {%- endif %}
-      {%- endif %}
-    {%- endif %}"
-  {%- endif %}
-  {%- if width > 412 %}
-    data-sizes="(min-resolution: 144dpi) 100vw,
-              50vw"
-  {%- endif %}
-  data-src="https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }}/{{ url }}"
+  {% if hi_def %}
+   data-srcset="https://res.cloudinary.com/canonical/image/fetch/{{ hi_def_cloudinary_options }}/{{ url }} 2x"
+  {% endif %}
+  data-src="https://res.cloudinary.com/canonical/image/fetch/{{ std_def_cloudinary_options }}/{{ url }}"
   alt="{{ alt }}"
   width="{{ width }}"
   height="{{ height }}"
   class="lazyload{% if extra_classes %} {{ extra_classes }}{% endif %}"
-{%- for attr_name, attr_value in attributes.items() %}
-  {{ attr_name }}="{{ attr_value }}"
-{%- endfor %}
+  {% for attr_name, attr_value in attributes.items() %}
+    {{ attr_name }}="{{ attr_value }}"
+  {% endfor %}
 />
 
 <noscript>
   <img
-  {%- if width > 412 %}
-    srcset="https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }},w_412/{{ url }} 460w
-                 ,https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }},w_824/{{ url }} 920w
-    {%- if width > 572 %}
-                 ,https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }},w_572/{{ url }} 620w
-                 ,https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }},w_1144/{{ url }} 1240w
-      {%- if width > 720 %}
-                 ,https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }},w_720/{{ url }} 767w
-                 ,https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }},w_1440/{{ url }} 1534w
-        {%- if width > 990 %}
-                 ,https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }},w_990/{{ url }} 1030w
-                 ,https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }},w_1980/{{ url }} 2060w
-        {%- endif %}
-      {%- endif %}
-    {%- endif %}"
-  {%- endif %}
-    {%- if width > 412 %}
-      sizes="(min-resolution: 144dpi) 100vw,
-              50vw"
-    {%- endif %}
-    src="https://res.cloudinary.com/canonical/image/fetch/{{ cloudinary_options }}/{{ url }}"
+    {% if hi_def %}
+      srcset="https://res.cloudinary.com/canonical/image/fetch/{{ hi_def_cloudinary_options }}/{{ url }} 2x"
+    {% endif %}
+    src="https://res.cloudinary.com/canonical/image/fetch/{{ std_def_cloudinary_options }}/{{ url }}"
     alt="{{ alt }}"
     width="{{ width }}"
     height="{{ height }}"
-{%- if extra_classes %}
-    class="{{ extra_classes }}"
-{%- endif %}
-{%- for attr_name, attr_value in attributes.items() %}
-    {{ attr_name }}="{{ attr_value }}"
-{%- endfor %}
+    {% if extra_classes %}
+      class="{{ extra_classes }}"
+    {% endif %}
+    {% for attr_name, attr_value in attributes.items() %}
+      {{ attr_name }}="{{ attr_value }}"
+    {% endfor %}
   />
 </noscript>

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -81,28 +81,6 @@ class TestImageTemplate(unittest.TestCase):
         self.assertTrue(markup_asset.find("x2"))
         self.assertTrue(markup_asset.find("w%3D3840%26h%3D2160"))
 
-    def test_assets_url_has_width_and_height(self):
-        markup_asset = image_template(
-            url=asset_url,
-            alt="test",
-            width="1920",
-            height="1080",
-            hi_def=False,
-        )
-        markup_non_asset = image_template(
-            url=non_asset_url,
-            alt="test",
-            width="1920",
-            height="1080",
-            hi_def=False,
-        )
-
-        self.assertTrue(
-            encoded_asset_url + "%3Fw%3D1920%26h%3D1080" in markup_asset
-        )
-        self.assertTrue("w_1920" not in markup_asset)
-        self.assertTrue("w_1920" in markup_non_asset)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -3,11 +3,13 @@ import unittest
 
 # Local
 from canonicalwebteam import image_template
+from urllib.parse import quote
 
 
 asset_url = (
     "https://assets.ubuntu.com/" "v1/479958ed-vivid-hero-takeover-kylin.jpg"
 )
+encoded_asset_url = quote(asset_url)
 non_asset_url = (
     "https://dashboard.snapcraft.io/site_media/appmedia/"
     "2018/10/Screenshot_from_2018-10-26_14-20-14.png"
@@ -18,7 +20,11 @@ non_hostname_url = "/static/images/Screenshot_from_2018-10-26_14-20-14.png"
 class TestImageTemplate(unittest.TestCase):
     def test_returns_string(self):
         markup = image_template(
-            url=asset_url, alt="test", width="1920", height="1080"
+            url=asset_url,
+            alt="test",
+            width="1920",
+            height="1080",
+            hi_def=False,
         )
         self.assertTrue(isinstance(markup, str))
 
@@ -30,6 +36,7 @@ class TestImageTemplate(unittest.TestCase):
             height="1080",
             id="test",
             title="test title",
+            hi_def=False,
         )
         self.assertTrue(markup.find('id="test"') > -1)
         self.assertTrue(markup.find('title="test title"') > -1)
@@ -41,20 +48,58 @@ class TestImageTemplate(unittest.TestCase):
             width="1920",
             height="1080",
             extra_classes="test-title",
+            hi_def=False,
         )
         # Check custom class exists
         self.assertTrue(markup.find('class="test-title"') > -1)
         # Check lazyload class still exists
         self.assertTrue(markup.find('class="lazyload test-title"') > -1)
 
+    def test_hi_def(self):
+        markup = image_template(
+            url=non_asset_url,
+            alt="test",
+            width="1920",
+            height="1080",
+            hi_def=True,
+        )
+        markup_asset = image_template(
+            url=asset_url, alt="test", width="1920", height="1080", hi_def=True
+        )
+
+        # Check the markup includes srcset
+        self.assertTrue(markup.find("srcset="))
+        self.assertTrue(markup.find("data-srcset"))
+        # Check x2 is present
+        self.assertTrue(markup.find("x2"))
+        # Check width and height are double
+        self.assertTrue(markup.find("3840"))
+        self.assertTrue(markup.find("2160"))
+
+        self.assertTrue(markup_asset.find("srcset="))
+        self.assertTrue(markup_asset.find("data-srcset"))
+        self.assertTrue(markup_asset.find("x2"))
+        self.assertTrue(markup_asset.find("w%3D3840%26h%3D2160"))
+
     def test_assets_url_has_width_and_height(self):
         markup_asset = image_template(
-            url=asset_url, alt="test", width="1920", height="1080"
+            url=asset_url,
+            alt="test",
+            width="1920",
+            height="1080",
+            hi_def=False,
         )
         markup_non_asset = image_template(
-            url=non_asset_url, alt="test", width="1920", height="1080"
+            url=non_asset_url,
+            alt="test",
+            width="1920",
+            height="1080",
+            hi_def=False,
         )
-        self.assertTrue(asset_url + "?w=1920&h=1080" in markup_asset)
+
+        self.assertTrue(
+            encoded_asset_url + "%3Fw%3D1920%26h%3D1080" in markup_asset
+        )
         self.assertTrue("w_1920" not in markup_asset)
         self.assertTrue("w_1920" in markup_non_asset)
 


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/image-template/issues/17 or at least the conversation that was had.

## DONE
- Removed asset server resizing - ~through testing noticed that the original image on Cloudinary was always the full source image... Something to investigate in the future, if storage usage on Cloudinary is an issue~ further investigation shows that _only_ resizing with Cloudinary produces consistently smaller file sizes.
- Added `hi_def` param - if set the module expects an image at least 2x that of the `width` and `height` params to be uploaded. For example if you have `url="test.png" width="200" height="200" hi_def=True` it is expected that `test.png` is at least 400 x 400.
- Removed multiple `srcsets` from the generated HTML and replaced with a simple `2x` version. This greatly simplifies the module output.

Overall I've put these changes in place to make the module somewhat useful ASAP, and a simplified base that we can implement and build upon. The original goal of the module I fear was too complicated, stripping it back and getting it in production will hopefully inform future modifications.

## QA
- Pull the branch
- Create a simple `app.py` file
```
import sys

sys.path.insert(
    1, "PATH_TO_MODULE/image-template/canonicalwebteam"
)

import image_template

image_markup = image_template(
    url="https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Linux_Screenshare-01.png",
    alt="skype",
    width="430",
    height="242",
    hi_def=False,
)

print(image_markup)

image_markup_2 = image_template(
    url="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png",
    alt="test",
    width="1040",
    height="585",
    hi_def=True,
)

print(image_markup_2)
```
- `python app.py`
- Some markup should be printed in your terminal
- Copy/paste to codepen/ HTML file
- Toggle dpi settings in your browser to see the different images used